### PR TITLE
WIP: Add tailwind-jit transformation

### DIFF
--- a/core/styles/private/GetTransformations.html
+++ b/core/styles/private/GetTransformations.html
@@ -9,6 +9,7 @@
   - PostCSS
   - PostProcess
   - tailwind
+  - tailwind-jit
   - toCSS
 
   @author @regisphilibert
@@ -35,6 +36,8 @@
 {{ with .use }}
   {{ if in . "tailwind" }}
     {{ $transformations = $transformations | append (slice "tailwind" "PostCSS") }}
+  {{ else if in . "tailwind-jit" }}
+  {{ $transformations = $transformations | append (slice "tailwind" "tailwind-jit" "PostCSS") }}
   {{ else }}
     {{ if in . "postcss" }}
       {{ $transformations = $transformations | append "PostCSS" }}

--- a/core/styles/private/transform/tailwind-jit.html
+++ b/core/styles/private/transform/tailwind-jit.html
@@ -1,0 +1,9 @@
+{{/* 
+  For now a workaround, as Hugo is not yet supporting Tailwind-JIT.
+  See https://dev.to/jonas_duri/how-to-use-tailwindcss-30-without-external-npm-scripts-just-hugo-pipes-2lg9 from @Gioni06
+  */}}
+{{ $resource := . }}
+{{ if site.IsServer }}
+  {{ $resource = . | resources.ExecuteAsTemplate (printf "tailwind.dev.%v.css" now.UnixMilli) . }}
+{{ end }}
+{{ return $resource }}


### PR DESCRIPTION
This PR, not ready for promotion, (but maybe use?) is here if we need it. 

This will essentially use the current best workaround to run Hugo Pipe + JIT described by @Gioni06 here: https://dev.to/jonas_duri/how-to-use-tailwindcss-30-without-external-npm-scripts-just-hugo-pipes-2lg9

**Requires Node 16**

```yaml
# _huge/config/styles.yaml
styles:
- name: main
  path: css/main.scss
  use:
    - tailwind-jit
```

<del>The `stdin ` error (reported as fixed in Tailwind 3.0.11) is still there for me. So it means a I had to add a `stdin` empty file at be root of the repo to have this work. Less than ideal. </del>

Addresses #43