### PR TITLE
Fonts: Fine tune `preload`, retire `prefetch`

### DIFF
--- a/core/fonts/private/GetFormat.html
+++ b/core/fonts/private/GetFormat.html
@@ -11,9 +11,21 @@
   @returns String
 
 */}}
-{{ $format := "" }}
-{{ $format = .MediaType.SubType }}
-{{ $irregular := dict "vnd.ms-fontobject" "embedded-opentype" "ttf" "truetype" "font-sfnt" "truetype" "otf" "opentype" }}
+{{ $format := "woff2" }}
+{{/* It appears CloudFlare produces an empty string when calling .MediaType.SubType on a woff2...
+    As this is by far the best font format these days in terms of support and optimization,
+    making it default to ensure it is not botched by cloudflare is "ok".
+*/}}
+{{ with .MediaType.SubType }}
+  {{ $format = . }}
+{{ end }}
+{{ $irregular := dict 
+  "vnd.ms-fontobject" "embedded-opentype"
+  "font-woff" "woff"
+  "ttf" "truetype"
+  "font-sfnt" "truetype" 
+  "otf" "opentype" 
+}}
 {{ with index $irregular $format }}
   {{ $format = . }}
 {{ end }}

--- a/core/fonts/private/GetFormat.html
+++ b/core/fonts/private/GetFormat.html
@@ -1,0 +1,21 @@
+{{/*
+  GetFormat
+  Retrieves the font format of a given resource
+
+  @author @regisphilibert
+
+  @context Resource (.)
+
+  @access private
+
+  @returns String
+
+*/}}
+{{ $format := "" }}
+{{ $format = .MediaType.SubType }}
+{{ $irregular := dict "vnd.ms-fontobject" "embedded-opentype" "ttf" "truetype" "font-sfnt" "truetype" "otf" "opentype" }}
+{{ with index $irregular $format }}
+  {{ $format = . }}
+{{ end }}
+
+{{ return $format }}

--- a/core/fonts/private/GetPreloadTags.html
+++ b/core/fonts/private/GetPreloadTags.html
@@ -1,0 +1,41 @@
+{{/*
+  huge/fonts/private/GetPreloadTags
+  Construct the tags data based on preload settings.
+
+  @author @regisphilibert
+
+  @context Any (.)
+
+  @access private
+
+  @returns Slice of Maps (complying to https://github.com/theNewDynamic/hugo-module-tnd-tags/blob/main/README.md)
+
+  @uses
+     - huge/fonts/private/GetFonts
+     - huge/fonts/private/GetFormat
+*/}}
+{{ $tags := slice }}
+{{/* We list all the fonts in order to produce the data for the "prefetch" tags on all its required files */}}
+{{ range partialCached "huge/fonts/private/GetFonts" "GetFonts" }}
+{{/* We want to print <link rel="preload" href="font.woff2" as="font" type="font/woff2" crossorigin> */}}
+  {{ range .resources }}
+    {{ $format := partialCached "huge/fonts/private/GetFormat" . .MediaType.SubType }}
+    {{/* For now it makes sens to restrict preload to the most supported file format.
+        Future release will allow other file formats to be preloaded.
+      */}}
+    {{ if eq $format "woff2" }}
+      {{ $tag := dict
+        "name" "link"
+        "attr" (dict
+          "href" .RelPermalink
+          "as" "font"
+          "type" "font/woff2"
+          "rel" "preload"
+          "crossorigin" "anonymous"
+      )}}
+      {{ $tags = $tags | append $tag }}
+    {{ end }}
+  {{ end }}
+{{ end }}
+
+{{ return $tags }}

--- a/core/fonts/private/GetTags.html
+++ b/core/fonts/private/GetTags.html
@@ -17,6 +17,16 @@
 {{ $tags := slice }}
 {{ $config := partialCached "huge/config/Get" "fonts" "fonts" }}
 
+
+{{/* Preload default is "always" */}}
+{{ $preload := $config.preload | default "always" }}
+{{ if partialCached "huge/env/When" $preload $preload }}
+  {{ with partial "huge/fonts/private/GetPreloadTags" }}
+    {{ $tags = $tags | append . }}
+  {{ end }}
+{{ end }}
+
+
 {{/* We generate a resource from Template (to facilitate future manipulation/http request) */}}
 {{ $fontface := resources.Get "/huge_only/fontface.css" | resources.ExecuteAsTemplate "fontface.css" "no_context" }}
 {{/* Add the tag with Resource's .Content for "inner" */}}
@@ -25,30 +35,5 @@
   "inner" $fontface.Content
 }} 
 {{ $tags = $tags | append $fontface_tag }}
-
-{{/* If prefetching is enabled on the package's config */}}
-{{ $prefetch := $config.prefetch | default "always" }}
-{{ if partialCached "huge/env/When" $prefetch $prefetch }}
-  {{/* We list all the fonts in order to produce the data for the "prefetch" tags on all its required files */}}
-  {{ range partialCached "huge/fonts/private/GetFonts" "GetFonts" }}
-  {{/* We want to print <link rel="preload" href="font.woff2" as="font" type="font/woff2" crossorigin> */}}
-    {{ range .resources }}
-      {{ $format := partialCached "huge/fonts/private/GetFormat" . .MediaType.SubType }}
-      {{ if true }}
-        {{ $tag := dict
-          "name" "link"
-          "attr" (dict
-            "href" .RelPermalink
-            "as" "font"
-            "type" (printf "font/%s" $format)
-            "rel" "preload"
-            "crossorigin" " "
-        )}}
-        {{ $tags = $tags | append $tag }}
-      {{ end }}
-
-    {{ end }}
-  {{ end }}
-{{ end }}
 
 {{ return $tags }}

--- a/core/fonts/private/GetTags.html
+++ b/core/fonts/private/GetTags.html
@@ -31,16 +31,22 @@
 {{ if partialCached "huge/env/When" $prefetch $prefetch }}
   {{/* We list all the fonts in order to produce the data for the "prefetch" tags on all its required files */}}
   {{ range partialCached "huge/fonts/private/GetFonts" "GetFonts" }}
+  {{/* We want to print <link rel="preload" href="font.woff2" as="font" type="font/woff2" crossorigin> */}}
     {{ range .resources }}
-      {{ $tag := dict
-        "name" "link"
-        "attr" (dict
-          "href" .RelPermalink
-          "as" "font"
-          "crossorigin" " "
-          "rel" "prefetch"
-      )}}
-      {{ $tags = $tags | append $tag }}
+      {{ $format := partialCached "huge/fonts/private/GetFormat" . .MediaType.SubType }}
+      {{ if true }}
+        {{ $tag := dict
+          "name" "link"
+          "attr" (dict
+            "href" .RelPermalink
+            "as" "font"
+            "type" (printf "font/%s" $format)
+            "rel" "preload"
+            "crossorigin" " "
+        )}}
+        {{ $tags = $tags | append $tag }}
+      {{ end }}
+
     {{ end }}
   {{ end }}
 {{ end }}

--- a/core/fonts/private/ParseFont.html
+++ b/core/fonts/private/ParseFont.html
@@ -26,7 +26,10 @@
 {{ $font := . }}
 {{ with .file }}
   {{ with resources.Match (print "/" . ".*") }}
-    {{ $font = merge $font (dict "resources" .) }}
+    {{/* This ensures woff2 and woff are declared first, it seems we can't realy rely on SubType (cloufflare as '' for woff2...) */}}
+    {{ with sort . "Name" "desc" }}
+      {{ $font = merge $font (dict "resources" (sort . "Name" "desc")) }}
+    {{ end }}
   {{ else }}
   {{ partial "huge/console/warn" (printf "We did not find matching font files for basename `%s`.\nFont files should be added to the project's `assets` directory and match the relative path set in the font's settings." .) }}
   {{ end }}

--- a/core/fonts/private/ParseFontface.html
+++ b/core/fonts/private/ParseFontface.html
@@ -58,6 +58,7 @@ we add font-{property} to the valid properties */}}
 {{ range $properties }}
   {{ $properties = $properties | append (print "font-" .) }}
 {{ end }}
+
 {{ range $property := $properties }}
   {{ with index $ . }}
     {{ $key := $property }}
@@ -67,6 +68,10 @@ we add font-{property} to the valid properties */}}
     {{ end }}
     {{ $s.SetInMap "font" $key . }}
   {{ end }}
+{{ end }}
+
+{{ if not (index ($s.Get "font") "font-display") }}
+  {{ $s.SetInMap "font" "font-display" "swap" }}
 {{ end }}
 
 {{ return $s.Get "font" }}

--- a/core/fonts/private/ParseFontface.html
+++ b/core/fonts/private/ParseFontface.html
@@ -34,11 +34,7 @@
     {{ end }}
 
     {{ range . }}
-      {{ $format := .MediaType.SubType }}
-      {{ $irregular := dict "vnd.ms-fontobject" "embedded-opentype" "ttf" "truetype" "font-sfnt" "truetype" "otf" "opentype" }}
-      {{ with index $irregular $format }}
-        {{ $format = . }}
-      {{ end }}
+      {{ $format := partialCached "huge/fonts/private/GetFormat" . .MediaType.SubType }}
       {{ $css_srcs = $css_srcs | append (printf `url("%s") format("%s")` .RelPermalink $format) }}
     {{ end }}
     {{ with $css_srcs }}


### PR DESCRIPTION
`prefetch` has been a mistake, we should have always used preload.

This replaces the `prefetch` key setting by `preload`

There is a few things to consider:

Loading ALL font formats is a bad practice, for now we'll limit preloading to `woff2` files, as this is the most efficient and supported format. There's very few reasons for a user not to have a `woff2` file. (We'll give more freedom in the future).

We also ensure the font-face ordering is now: `woff2`, `woff`, `ttf` etc...

Fixes #63 