### PR TITLE
WIP: Allow Go Template in config file

### DIFF
--- a/core/config/Get.html
+++ b/core/config/Get.html
@@ -21,9 +21,15 @@
 {{ $config := dict }}
 {{ $dir := "_huge/config" }}
 
-{{ with resources.GetMatch (printf "/%s/%s.*" $dir $) }}
+{{ with $resource := resources.GetMatch (printf "/%s/%s.*" $dir $) }}
   {{ with .Content }}
-    {{ $config = . | transform.Unmarshal }}
+    {{ $content := . }}
+    {{ if in . "{{" }}
+      {{ with resources.ExecuteAsTemplate $ "context" $resource }}
+        {{ $content = .Content }}
+      {{ end }}
+    {{ end }}
+    {{ $config = $content | transform.Unmarshal }}
   {{ end }}
 {{ end }}
 


### PR DESCRIPTION
Basically allows:

```
# _huge/config/seo.yaml
enable_follow: true
default_image: {{ site.Home.Params.featured_image }}
```

Fixes #74